### PR TITLE
Update H2 database

### DIFF
--- a/quickstart-hibernate/quickstart-hibernate-xml/pom.xml
+++ b/quickstart-hibernate/quickstart-hibernate-xml/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <h2.version>1.4.197</h2.version>
+    <h2.version>2.0.206</h2.version>
 
   </properties>
 


### PR DESCRIPTION
This fixes this security issue:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392.
More info here:
GHSA-h376-j262-vhq6